### PR TITLE
Refactor main class to make it simpler to use

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,9 +4,46 @@ This is a GPFS puppet module to install and configure the General Parallel File 
 
 # Prerequisites
 
-Licenses to use GPFS will be required from IBM, as well as the install package (`gpfs.base`) and updates (`gpfs.base*update.rpm`) from which a kernal ports package (`gpfs.ports`) will need to be compiled for the specific kernel being used on your systems.
+Licenses to use GPFS will be required from IBM, as well as the install package (`gpfs.base`) and updates (`gpfs.base*update.rpm`) from which a kernel specific package (`gpfs.gplbin`) will need to be compiled for the kernel release being used on your systems.
 
 This module can then be used to distribute and install these packages over many Puppet managed servers.
+
+# Building the binary RPM
+
+This are generic steps to build the binary package for GPFS 3.5.0-18 on RHEL 6.5. YMMV
+
+* Install rpm-build, gcc-c++ (you might need more packages depending on what you install by default)
+* Install GPFS's base RPMs
+* Install GPFS's update RPMs
+* Configure GPFS
+```Shell
+# You might have to pass LINUX_DISTRIBUTION= if your OS version is not recognised (GPFS v3.5.0 needed it for RHEL6)
+make Autoconfig LINUX_DISTRIBUTION=REDHAT_RHEL6
+```
+* Build GPFS
+```Shell
+  make World
+  make rpm
+```
+
+# Usage
+
+Basic usage:
+
+```Puppet
+class { '::gpfs':
+  source_url => '/path/to/gpfs/rpms',
+  version    => '3.5.0',
+  update     => '18',
+}
+```
+
+Will install:
+ * `/path/to/gpfs/rpms/gpfs.base-3.5.0-0.${::architecture}.rpm`
+ * `/path/to/gpfs/rpms/gpfs.base-3.5.0-18.${::architecture}.update.rpm`
+ * `/path/to/gpfs/rpms/gpfs.gplbin-${::kernelrelease}-3.5.0-0.${::architecture}.rpm`
+
+using facts for the kernel release and architecture.
 
 # References
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,27 +28,36 @@
 
 # [Remember: No empty lines between comments and class definition]
 class gpfs(
+  $source_url,
+  $version,
+  $update,
+  $manage_deps = false,
   $kernel_version = $::kernelrelease,
-  $base_source,
-  $update_source,
-  $ports_source
-){
+) {
 
-  $gpfs_deps = ['compat-libstdc++-33','libstdc++','rsh','ksh']
+  $base_source   = "${source_url}/gpfs.base-${version}-0.${::architecture}.rpm"
+  $update_source = "${source_url}/gpfs.base-${version}-${update}.${::architecture}.update.rpm"
+  $ports_source  = "${source_url}/gpfs.gplbin-${kernel_version}-${version}-${update}.${::architecture}.rpm"
 
-  package {$gpfs_deps:
-    ensure  => installed
-  }
+  if $manage_deps {
+    $gpfs_deps = ['compat-libstdc++-33','libstdc++','rsh','ksh']
 
-  package {"kernel-${kernel_version}":
-    ensure => installed,
+    package {$gpfs_deps:
+      ensure  => installed,
+      before  => Package['gpfs.base'],
+    }
+
+
+    package {"kernel-${kernel_version}":
+      ensure => installed,
+      before  => Package['gpfs.base'],
+    }
   }
 
   package {"gpfs.base":
     provider  => 'rpm',
     ensure    => installed,
     source    => $base_source,
-    require   => [Package[$gpfs_deps]],
   }
 
   # The gpfs.update package conflicts with the gpfs.base package

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,11 +85,7 @@ class gpfs(
     require => Exec['gpfs.update']
   }
 
-  if $ports_source =~ /(gpfs.gplbin-.*)\.rpm/ {
-    $port_package = $1
-  }
-
-  package {$port_package:
+  package {'gpfs.gplbin':
     provider  => 'rpm',
     ensure    => installed,
     source    => $ports_source,

--- a/spec/classes/gpfs_spec.rb
+++ b/spec/classes/gpfs_spec.rb
@@ -4,15 +4,18 @@ describe 'gpfs', :type => :class do
   context "on a RedHat OS" do
     let :facts do
       {
-        :osfamily   => 'RedHat'
+        :osfamily       => 'RedHat',
+        :kernel_release => '2.6.32-431.el6',
+        :architecture   => 'x86_64'
       }
     end
     let(:params){ 
       {
+        :source_url     => "/path/to/gpfs/rpms",
+        :version        => "3.5.0",
+        :update         => "18",
+        :manage_deps    => true,
         :kernel_version => "2.6.32-358.6.1.el6",
-        :base_source    => "/path/to/gpfs.base.rpm",
-        :update_source  => "/path/to/gpfs.base.update.rpm",
-        :ports_source   => "/path/to/gpfs.ports.rpm",
       }
     }
     it { should contain_package("rsh")}
@@ -23,14 +26,14 @@ describe 'gpfs', :type => :class do
     it { should contain_package("gpfs.base").with
       {
         :provider  => 'rpm',
-        :source    => "/path/to/gpfs.base.rpm",
+        :source    => "/path/to/gpfs.base-3.5.0-0.x86_64.rpm",
       }
     }
     it { should contain_exec("gpfs.update") }
-    it { should contain_package("gpfs.port").with
+    it { should contain_package("gpfs.gplbin").with
       {
         :provider  => 'rpm',
-        :source    => "/path/to/gpfs.ports.rpm",
+        :source    => "/path/to/gpfs.gplbin-2.6.32-431.el6.x86_64-3.5.0-18.x86_64.rpm",
       }
     }
   end


### PR DESCRIPTION
I've refactored the main class so that you don't have to specify the kernel version for the gpfs.gplbin package.

It now takes base URL, GPFS version and update level.

I've only tested this on RHEL 6.5 and GPFS v3.5.0 update 18.

I've also updated the README with basic usage example and instructions to build the gplbin RPM.